### PR TITLE
fixed missed log4g configuration file log message

### DIFF
--- a/cmd/kplr/main.go
+++ b/cmd/kplr/main.go
@@ -94,7 +94,7 @@ func parseCLP() (*Config, error) {
 
 	if *logCfgFile != "" {
 		if kplr.IsFileNotExist(*logCfgFile) {
-			kplr.DefaultLogger.Warn("No file ", logCfgFile, " will use default log4g configuration")
+			kplr.DefaultLogger.Warn("No file ", *logCfgFile, " will use default log4g configuration")
 		} else {
 			err := log4g.ConfigF(*logCfgFile)
 			if err != nil {


### PR DESCRIPTION
Change log 
> WARN  kplr: No file 0xc42020adb0 will use default log4g configuration

to:
> WARN  kplr: No file /opt/kplr/log4g.properties will use default log4g configuration